### PR TITLE
Improve safely_execute return structure

### DIFF
--- a/R/utils_error_handling.R
+++ b/R/utils_error_handling.R
@@ -14,8 +14,15 @@
 #'                  if an error occurs (default: `TRUE`).
 #' @param call The call to evaluate. Passed to `purrr::safely` for more informative
 #'             error messages.
+#' @param return_result_list Logical. If `TRUE`, the function returns a list
+#'                           containing both the result and any caught error
+#'                           (default is controlled by the option
+#'                           `horizons.return_safely_result`, which is `FALSE`).
 #'
-#' @return The result of `expr` if successful, or `default_value` if an error occurs.
+#' @return If `return_result_list` is `FALSE` (default), the result of `expr` if
+#'         successful, or `default_value` if an error occurs. If
+#'         `return_result_list` is `TRUE`, a list with components `result` and
+#'         `error` is returned.
 #'
 #' @importFrom purrr safely
 #' @importFrom cli cli_warn
@@ -25,10 +32,11 @@
 
 
 safely_execute <- function(expr,
-                           default_value = NULL,
-                           error_message = NULL,
-                           log_error     = TRUE,
-                           call          = rlang::caller_env()) {
+                           default_value       = NULL,
+                           error_message       = NULL,
+                           log_error           = TRUE,
+                           call                = rlang::caller_env(),
+                           return_result_list  = getOption("horizons.return_safely_result", FALSE)) {
 
   ## ---------------------------------------------------------------------------
   ## Step 1: Capture the expression into a quosure.
@@ -82,6 +90,10 @@ safely_execute <- function(expr,
           }
       }
 
+    if (return_result_list) {
+      return(structure(list(result = default_value, error = result_list$error),
+                       class = "horizons_safely_result"))
+    }
     return(default_value)
 
   }
@@ -90,6 +102,11 @@ safely_execute <- function(expr,
   ## Step 5: Return the result if no error occurred.
   ## ---------------------------------------------------------------------------
 
+
+  if (return_result_list) {
+    return(structure(list(result = result_list$result, error = NULL),
+                     class = "horizons_safely_result"))
+  }
 
   return(result_list$result)
 }

--- a/man/safely_execute.Rd
+++ b/man/safely_execute.Rd
@@ -9,7 +9,8 @@ safely_execute(
   default_value = NULL,
   error_message = NULL,
   log_error = TRUE,
-  call = rlang::caller_env()
+  call = rlang::caller_env(),
+  return_result_list = getOption("horizons.return_safely_result", FALSE)
 )
 }
 \arguments{
@@ -27,9 +28,16 @@ if an error occurs (default: \code{TRUE}).}
 
 \item{call}{The call to evaluate. Passed to \code{purrr::safely} for more informative
 error messages.}
+
+\item{return_result_list}{Logical. If \code{TRUE}, the function returns a list containing
+the result and any caught error. Defaults to the option
+\code{horizons.return_safely_result} which is \code{FALSE}.}
 }
 \value{
-The result of \code{expr} if successful, or \code{default_value} if an error occurs.
+If \code{return_result_list} is \code{FALSE} (default), the result of \code{expr}
+if successful or \code{default_value} if an error occurs. If
+\code{return_result_list} is \code{TRUE}, a list with components \code{result}
+and \code{error} is returned.
 }
 \description{
 This helper function wraps an expression or function call using \code{purrr::safely()}

--- a/tests/testthat/test-safely_execute.R
+++ b/tests/testthat/test-safely_execute.R
@@ -1,0 +1,17 @@
+test_that("safely_execute returns value when no error", {
+  res <- horizons:::safely_execute({1 + 1})
+  expect_equal(res, 2)
+})
+
+test_that("safely_execute can return result list", {
+  res <- horizons:::safely_execute({1 + 1}, return_result_list = TRUE)
+  expect_equal(res$result, 2)
+  expect_null(res$error)
+})
+
+test_that("safely_execute returns default and error on failure", {
+  res <- horizons:::safely_execute({stop("oops")}, default_value = NA,
+                                    log_error = FALSE, return_result_list = TRUE)
+  expect_true(inherits(res$error, "error"))
+  expect_true(is.na(res$result))
+})


### PR DESCRIPTION
## Summary
- allow `safely_execute()` to optionally return a list containing the result and error
- document new behaviour
- test new helper behaviour

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_684b31910730832bb2fbd28b5cc8388b