### PR TITLE
Improve safe_run_model error logging

### DIFF
--- a/R/evaluation-safely_run_single_evaluation.R
+++ b/R/evaluation-safely_run_single_evaluation.R
@@ -26,7 +26,7 @@
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{status_summary}{A one-row tibble with model ID, RMSE, R², pruned file path, error path, and status flag.}
+#'   \item{status_summary}{A one-row tibble with model ID, RMSE, R², pruned file path, error path, error message, and status flag.}
 #'   \item{pruned_output_path}{Path to `.qs` file with pruned model result (if successful).}
 #' }
 #'
@@ -80,8 +80,12 @@ safe_run_model <- function(config_row,
                                                grid_size          = grid_size,
                                                bayesian_iter      = bayesian_iter,
                                                cv_folds           = cv_folds)},
-    default_value = NULL,
-    error_message = "Failed model run at config row {row_index}: {config_desc}") -> model_res
+                 default_value     = NULL,
+                 error_message     = "Failed model run at config row {row_index}: {config_desc}",
+                 return_result_list = TRUE) -> model_res_safe
+
+  model_res  <- model_res_safe$result
+  run_error  <- model_res_safe$error
 
   ## ---------------------------------------------------------------------------
   ## Step 3: Handle null result (true error, not just pruned)
@@ -93,8 +97,8 @@ safe_run_model <- function(config_row,
 
     error_obj <- list(row           = row_index,
                       config        = config_row,
-                      error_message = "evaluate_model_config() returned NULL",
-                      reason        = model_res$error_message,
+                      error_message = if (!is.null(run_error)) run_error$message else "evaluate_model_config() returned NULL",
+                      call          = if (!is.null(run_error)) deparse(run_error$call) else NULL,
                       time          = as.character(Sys.time()))
 
     jsonlite::write_json(error_obj, error_file, pretty = TRUE, auto_unbox = TRUE)
@@ -106,6 +110,7 @@ safe_run_model <- function(config_row,
                    rrmse              = NA_real_,
                    output_path        = NA_character_,
                    error_log_path     = error_file,
+                   error_message      = error_obj$error_message,
                    status             = "error") -> status_summary
 
     cli::cli_alert_danger("Model run failed at: {row_index} - {config_desc}")
@@ -128,6 +133,7 @@ safe_run_model <- function(config_row,
                  rrmse              = NA_real_,
                  output_path        = NA_character_,
                  error_log_path     = NA_character_,
+                 error_message      = if (isTRUE(model_res$error)) model_res$reason else NA_character_,
                  status             = if (isTRUE(model_res$error)) "error"
                                       else if (isTRUE(model_res$pruned)) "pruned"
                                       else "success") -> status_summary

--- a/man/safe_run_model.Rd
+++ b/man/safe_run_model.Rd
@@ -40,7 +40,7 @@ safe_run_model(
 \value{
 A named list with:
 \describe{
-\item{status_summary}{A one-row tibble with model ID, RMSE, R², pruned file path, error path, and status flag.}
+\item{status_summary}{A one-row tibble with model ID, RMSE, R², pruned file path, error path, error message, and status flag.}
 \item{pruned_output_path}{Path to \code{.qs} file with pruned model result (if successful).}
 }
 }


### PR DESCRIPTION
## Summary
- inspect error object returned by safely_execute
- write useful message and call to JSON error log
- record error message in status summary

## Testing
- `Rscript -e "packageVersion('testthat')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_684b3758996c832b89218c765c66ace9