### PR TITLE
feat: implement average() for replicate aggregation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -149,3 +149,4 @@ Collate:
     'evaluation-ensemble.R'
     'pipeline-spectra.R'
     'pipeline-parse-ids.R'
+    'pipeline-average.R'

--- a/R/pipeline-average.R
+++ b/R/pipeline-average.R
@@ -1,0 +1,748 @@
+#' Average Replicate Spectra
+#'
+#' @description
+#' Functions for aggregating replicate spectra by sample ID with optional
+#' correlation-based quality control to detect outlier replicates.
+#'
+#' @details
+#' This module provides `average()`, which collapses replicate spectra into
+#' single mean spectra per sample. Quality control uses pairwise correlations
+#' to identify replicates that don't match their siblings.
+#'
+#' @keywords internal
+#' @name pipeline-average
+
+
+## =============================================================================
+## Section 1: Main Function
+## =============================================================================
+
+
+## ---------------------------------------------------------------------------
+## average() — Aggregate replicates with optional quality control
+## ---------------------------------------------------------------------------
+
+#' Average replicate spectra with quality control
+#'
+#' @description
+#' Aggregates replicate spectra by grouping column (default: `sample_id`) with
+#' optional correlation-based quality control to detect and handle outliers.
+#'
+#' @details
+#' **Quality Control:**
+#' When `quality_check = TRUE`, outliers are identified via iterative removal:
+#' 1. Compute mean pairwise correlation for each replicate
+#' 2. Remove the replicate with lowest mean correlation
+#' 3. Recompute correlations for remaining replicates
+#' 4. Repeat until all remaining replicates pass threshold (or only 1 remains)
+#'
+#' This iterative approach prevents a single bad replicate from dragging all
+#' others below threshold, which can happen with the simpler "flag all at once"
+#' method when group sizes are small (n=2-3).
+#'
+#' **Important:** Run `standardize()` with baseline correction before `average()`
+#' to ensure baseline shifts don't confound quality control. Spectra with baseline
+#' offsets can correlate ~1.0 but shouldn't be averaged without correction.
+#'
+#' **Handling All-Outlier Groups:**
+#' If QC reduces a group to a single replicate (all others removed):
+#' * `"warn"` (default): Keep the single replicate, emit warning
+#' * `"drop"`: Remove the entire sample from results
+#' * `"keep_best"`: Same as warn (already kept the best one)
+#'
+#' **Metadata Handling:**
+#' Metadata columns are checked for uniformity within groups:
+#' * Uniform values: preserved in output
+#' * Non-uniform values: column dropped (tracked in provenance)
+#' * `filename` column: always dropped (not meaningful after averaging)
+#'
+#' @param x A `horizons_data` object from the pipeline.
+#' @param by Character. Column name to group replicates by. Default: `"sample_id"`.
+#' @param quality_check Logical. Enable correlation-based outlier detection.
+#'   Default: `TRUE`.
+#' @param correlation_threshold Numeric. Minimum mean pairwise correlation for
+#'   a replicate to pass QC. Default: `0.996`. Changing this is rarely needed.
+#' @param on_all_outliers Character. Behavior when all replicates fail QC:
+#'   * `"warn"` (default): Keep all replicates and average
+#'   * `"drop"`: Remove the sample entirely
+#'   * `"keep_best"`: Keep only the replicate with highest mean correlation
+#' @param verbose Logical. Print progress messages. Default: `TRUE`.
+#'
+#' @return The input `horizons_data` object with:
+#'   * `data$analysis`: One row per unique value in `by` column
+#'   * Predictor columns: Mean of replicate values
+#'   * Metadata columns: Uniform values preserved, non-uniform dropped
+#'   * `data$role_map`: Updated to remove dropped columns
+#'   * `provenance$average`: Processing metadata including QC results
+#'
+#' @examples
+#' \dontrun{
+#' # Basic averaging after parsing IDs
+#' hd |>
+#'   standardize() |>
+#'   parse_ids(format = "{sample}_{rep}") |>
+#'   average()
+#'
+#' # Without quality control
+#' hd |> average(quality_check = FALSE)
+#'
+#' # Drop samples where all replicates are outliers
+#' hd |> average(on_all_outliers = "drop")
+#' }
+#'
+#' @export
+average <- function(x,
+                    by                    = "sample_id",
+                    quality_check         = TRUE,
+                    correlation_threshold = 0.996,
+                    on_all_outliers       = c("warn", "drop", "keep_best"),
+                    verbose               = TRUE) {
+
+  ## -------------------------------------------------------------------------
+  ## Step 1: Input validation
+  ## -------------------------------------------------------------------------
+
+  errors <- character()
+
+  ## Validate horizons_data object -------------------------------------------
+
+  if (!inherits(x, "horizons_data")) {
+
+    errors <- c(errors,
+                cli::format_inline("{.arg x} must be a horizons_data object, got {.cls {class(x)}}"))
+
+  }
+
+ ## Validate by column exists -----------------------------------------------
+
+  if (inherits(x, "horizons_data") && !by %in% names(x$data$analysis)) {
+
+    errors <- c(errors,
+                cli::format_inline("Grouping column {.val {by}} not found in data"))
+
+  }
+
+  ## Validate parameters -----------------------------------------------------
+
+  if (!is.logical(quality_check) || length(quality_check) != 1) {
+
+    errors <- c(errors,
+                cli::format_inline("{.arg quality_check} must be TRUE or FALSE"))
+
+  }
+
+  if (!is.numeric(correlation_threshold) || length(correlation_threshold) != 1 ||
+      correlation_threshold < 0 || correlation_threshold > 1) {
+
+    errors <- c(errors,
+                cli::format_inline("{.arg correlation_threshold} must be a number between 0 and 1"))
+
+  }
+
+  if (!is.character(on_all_outliers) || length(on_all_outliers) == 0) {
+
+    errors <- c(errors,
+                cli::format_inline("{.arg on_all_outliers} must be one of 'warn', 'drop', or 'keep_best'"))
+
+  }
+
+  ## Report validation errors with tree style --------------------------------
+
+  if (length(errors) > 0) {
+
+    cat(cli::col_red(cli::style_bold("! Input validation failed:\n")))
+
+    for (i in seq_along(errors)) {
+
+      branch <- if (i < length(errors)) "\u251C\u2500" else "\u2514\u2500"
+      cat(cli::col_red(paste0("   ", branch, " ", errors[i], "\n")))
+
+    }
+
+    cat("\n")
+    rlang::abort(paste(c("Input validation failed:", errors), collapse = "\n"),
+                 class = "horizons_validation_error")
+
+  }
+
+  on_all_outliers <- match.arg(on_all_outliers)
+
+  ## -------------------------------------------------------------------------
+  ## Step 2: Identify column roles
+  ## -------------------------------------------------------------------------
+
+  role_map <- x$data$role_map
+
+  ## Predictor columns (wavelengths) -----------------------------------------
+
+  predictor_cols <- role_map$variable[role_map$role == "predictor"]
+
+  if (length(predictor_cols) == 0) {
+
+    rlang::abort("No predictor columns found in role_map",
+                 class = "horizons_data_error")
+
+  }
+
+  ## Meta columns (excluding by column and filename) -------------------------
+
+  meta_cols <- role_map$variable[role_map$role == "meta"]
+  meta_cols <- setdiff(meta_cols, c(by, "filename"))
+
+  ## -------------------------------------------------------------------------
+  ## Step 3: Group analysis data
+  ## -------------------------------------------------------------------------
+
+  analysis <- x$data$analysis
+
+  ## Get grouping vector -----------------------------------------------------
+
+  group_values <- analysis[[by]]
+  unique_groups <- unique(group_values)
+  n_groups <- length(unique_groups)
+
+  if (verbose) {
+
+    cli::cli_text("")
+    cli::cli_text("\u2502")
+    cli::cli_text("\u251c\u2500 {cli::style_bold('Averaging replicates')}...")
+    cli::cli_text("\u2502  \u251c\u2500 Groups: {n_groups}")
+    cli::cli_text("\u2502  \u251c\u2500 Replicates: {nrow(analysis)}")
+    cli::cli_text("\u2502  \u2514\u2500 Quality check: {ifelse(quality_check, 'enabled', 'disabled')}")
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Step 4: Process each group
+  ## -------------------------------------------------------------------------
+
+  ## Initialize tracking -----------------------------------------------------
+
+  results_list        <- vector("list", n_groups)
+  n_dropped           <- 0
+  all_outlier_samples <- character()
+  dropped_samples     <- character()
+  qc_details          <- list()
+
+  for (i in seq_len(n_groups)) {
+
+    group_id   <- unique_groups[i]
+    group_idx  <- which(group_values == group_id)
+    group_data <- analysis[group_idx, , drop = FALSE]
+    n_reps     <- nrow(group_data)
+
+    ## Process group ---------------------------------------------------------
+
+    average_group(group_data          = group_data,
+                  group_id            = group_id,
+                  by                  = by,
+                  predictor_cols      = predictor_cols,
+                  meta_cols           = meta_cols,
+                  quality_check       = quality_check,
+                  threshold           = correlation_threshold,
+                  on_all_outliers     = on_all_outliers) -> group_result
+
+    ## Handle results --------------------------------------------------------
+
+    if (is.null(group_result$averaged)) {
+
+      ## Group was dropped (all outliers + drop mode) ------------------------
+
+      dropped_samples <- c(dropped_samples, as.character(group_id))
+      n_dropped <- n_dropped + n_reps
+
+    } else {
+
+      results_list[[i]] <- group_result$averaged
+      n_dropped <- n_dropped + group_result$n_dropped
+
+      if (group_result$all_outliers) {
+
+        all_outlier_samples <- c(all_outlier_samples, as.character(group_id))
+
+      }
+
+    }
+
+    ## Store QC details for provenance ---------------------------------------
+
+    if (quality_check && n_reps >= 2) {
+
+      qc_details[[as.character(group_id)]] <- group_result$qc_info
+
+    }
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Step 5: Combine results
+  ## -------------------------------------------------------------------------
+
+  ## Filter out NULLs (dropped groups) ---------------------------------------
+
+  results_list <- results_list[!sapply(results_list, is.null)]
+
+  if (length(results_list) == 0) {
+
+    cat(cli::col_red(cli::style_bold("! All samples dropped due to quality control:\n")))
+    cat(cli::col_red(paste0("   \u251C\u2500 ", n_groups, " samples had all replicates flagged as outliers\n")))
+    cat(cli::col_red(paste0("   \u2514\u2500 Consider on_all_outliers = 'warn' or lowering threshold\n")))
+    cat("\n")
+
+    rlang::abort("All samples dropped due to quality control",
+                 class = "horizons_qc_error")
+
+  }
+
+  averaged <- dplyr::bind_rows(results_list)
+
+  ## -------------------------------------------------------------------------
+  ## Step 6: Handle metadata uniformity
+  ## -------------------------------------------------------------------------
+
+  ## Check which meta columns were actually retained -------------------------
+
+  retained_meta <- intersect(meta_cols, names(averaged))
+  dropped_meta <- setdiff(meta_cols, retained_meta)
+
+  ## filename is always dropped (not in meta_cols already) -------------------
+
+  if ("filename" %in% names(x$data$analysis)) {
+
+    dropped_meta <- c("filename", dropped_meta)
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Step 7: Reorder columns
+  ## -------------------------------------------------------------------------
+
+  ## Order: by column, retained meta, predictors -----------------------------
+
+  col_order <- c(by, retained_meta, predictor_cols)
+  col_order <- col_order[col_order %in% names(averaged)]
+  averaged <- averaged[, col_order, drop = FALSE]
+
+  ## -------------------------------------------------------------------------
+  ## Step 8: Update role_map
+  ## -------------------------------------------------------------------------
+
+  new_role_map <- role_map[!role_map$variable %in% dropped_meta, , drop = FALSE]
+
+  ## -------------------------------------------------------------------------
+  ## Step 9: Update horizons_data object
+  ## -------------------------------------------------------------------------
+
+  x$data$analysis <- averaged
+  x$data$role_map <- new_role_map
+  x$data$n_rows <- nrow(averaged)
+
+  ## -------------------------------------------------------------------------
+  ## Step 10: Update provenance
+  ## -------------------------------------------------------------------------
+
+  x$provenance$average <- list(
+    by                    = by,
+    quality_check         = quality_check,
+    correlation_threshold = correlation_threshold,
+    on_all_outliers       = on_all_outliers,
+    n_groups              = n_groups,
+    n_replicates_before   = nrow(analysis),
+    n_replicates_after    = nrow(averaged),
+    n_replicates_dropped  = n_dropped,
+    samples_all_outliers  = all_outlier_samples,
+    samples_dropped       = dropped_samples,
+    meta_columns_dropped  = dropped_meta,
+    applied_at            = Sys.time()
+  )
+
+  x$provenance$aggregation_by <- by
+
+  ## -------------------------------------------------------------------------
+  ## Step 11: Emit warnings for all-outlier groups
+  ## -------------------------------------------------------------------------
+
+  if (length(all_outlier_samples) > 0 && on_all_outliers == "warn") {
+
+    cli::cli_warn(c(
+      "All replicates failed QC for {length(all_outlier_samples)} sample{?s}",
+      "i" = "Samples: {.val {head(all_outlier_samples, 5)}}",
+      if (length(all_outlier_samples) > 5) "i" = "... and {length(all_outlier_samples) - 5} more",
+      "i" = "Averaged anyway (consider {.code on_all_outliers = 'keep_best'})"
+    ))
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Step 12: Verbose output
+  ## -------------------------------------------------------------------------
+
+  if (verbose) {
+
+    cli::cli_text("\u2502")
+    cli::cli_text("\u2514\u2500 {cli::style_bold('Complete')}")
+    cli::cli_text("   \u251c\u2500 Samples: {nrow(averaged)}")
+
+    if (n_dropped > 0) {
+
+      cli::cli_text("   \u251c\u2500 Replicates dropped: {n_dropped}")
+
+    }
+
+    if (length(dropped_meta) > 0) {
+
+      cli::cli_text("   \u251c\u2500 Meta columns dropped: {length(dropped_meta)}")
+
+    }
+
+    if (length(all_outlier_samples) > 0) {
+
+      cli::cli_text("   \u2514\u2500 All-outlier samples: {length(all_outlier_samples)}")
+
+    } else {
+
+      cli::cli_text("   \u2514\u2500 QC: all groups clean")
+
+    }
+
+    cli::cli_text("")
+
+  }
+
+  x
+
+}
+
+
+## =============================================================================
+## Section 3: Helper Functions
+## =============================================================================
+
+
+## ---------------------------------------------------------------------------
+## compute_replicate_quality() — Iterative pairwise correlation QC
+## ---------------------------------------------------------------------------
+
+#' Compute replicate quality via iterative pairwise correlations
+#'
+#' @description
+#' Iteratively identifies outlier replicates by removing the worst one at a time
+#' and recomputing correlations. This prevents a single bad replicate from
+#' dragging all others below threshold.
+#'
+#' @param predictor_matrix Numeric matrix with rows = replicates, cols = wavelengths.
+#' @param threshold Numeric. Minimum mean correlation to pass QC.
+#'
+#' @return A list with:
+#'   * `outliers`: Integer indices of removed replicates (in original indexing)
+#'   * `all_fail`: Logical, TRUE if only 1 replicate survived (or none)
+#'   * `mean_cors`: Numeric vector of final mean correlations (NA for removed)
+#'
+#' @noRd
+compute_replicate_quality <- function(predictor_matrix, threshold) {
+
+  n <- nrow(predictor_matrix)
+
+  ## Single replicate: no QC possible ----------------------------------------
+
+  if (n < 2) {
+
+    return(list(
+      outliers  = integer(0),
+      all_fail  = FALSE,
+      mean_cors = NA_real_
+    ))
+
+  }
+
+  ## Track which rows are still active (not yet flagged as outliers) ---------
+
+  active_idx <- seq_len(n)
+  outliers <- integer(0)
+
+  ## Iteratively remove worst replicate until all pass or only 1 remains -----
+
+
+  repeat {
+
+    n_active <- length(active_idx)
+
+    ## If only 1 remains, stop (can't compute correlation) -------------------
+
+    if (n_active < 2) {
+
+      break
+
+    }
+
+    ## Compute correlation matrix for active replicates ----------------------
+
+    active_matrix <- predictor_matrix[active_idx, , drop = FALSE]
+
+    cor_matrix <- stats::cor(
+      t(active_matrix),
+      use = "pairwise.complete.obs"
+    )
+
+    ## Mean correlation for each active replicate (excluding self) -----------
+
+    diag(cor_matrix) <- NA
+    mean_cors_active <- rowMeans(cor_matrix, na.rm = TRUE)
+
+    ## Check if any are below threshold --------------------------------------
+
+    below_threshold <- which(mean_cors_active < threshold)
+
+    if (length(below_threshold) == 0) {
+
+      ## All active replicates pass ------------------------------------------
+
+      break
+
+    }
+
+    ## Remove the single worst replicate (lowest mean correlation) -----------
+    ## Even if all fail, removing the worst might let others pass on recompute
+
+    worst_active_idx <- which.min(mean_cors_active)
+    worst_original_idx <- active_idx[worst_active_idx]
+
+    outliers <- c(outliers, worst_original_idx)
+    active_idx <- active_idx[-worst_active_idx]
+
+  }
+
+  ## Compute final mean correlations for reporting ---------------------------
+
+  final_mean_cors <- rep(NA_real_, n)
+
+  if (length(active_idx) >= 2) {
+
+    active_matrix <- predictor_matrix[active_idx, , drop = FALSE]
+    cor_matrix <- stats::cor(t(active_matrix), use = "pairwise.complete.obs")
+    diag(cor_matrix) <- NA
+    final_mean_cors[active_idx] <- rowMeans(cor_matrix, na.rm = TRUE)
+
+  } else if (length(active_idx) == 1) {
+
+    final_mean_cors[active_idx] <- NA_real_
+
+  }
+
+  ## Determine if "all failed" ------------------------------------------------
+  ## With iterative removal, we define this as: only 1 replicate survived
+  ## (or all were removed, which shouldn't happen but handle it)
+
+  n_remaining <- length(active_idx)
+  all_fail <- n_remaining <= 1 && n >= 2
+
+  list(
+    outliers  = as.integer(outliers),
+    all_fail  = all_fail,
+    mean_cors = final_mean_cors
+  )
+
+}
+
+
+## ---------------------------------------------------------------------------
+## average_group() — Process single group
+## ---------------------------------------------------------------------------
+
+#' Process and average a single group of replicates
+#'
+#' @param group_data Tibble of replicates for one group.
+#' @param group_id The group identifier value.
+#' @param by Name of grouping column.
+#' @param predictor_cols Character vector of predictor column names.
+#' @param meta_cols Character vector of metadata column names.
+#' @param quality_check Logical. Enable QC.
+#' @param threshold Numeric. Correlation threshold.
+#' @param on_all_outliers Character. Handling mode for all-outlier groups.
+#'
+#' @return A list with:
+#'   * `averaged`: Single-row tibble (or NULL if dropped)
+#'   * `n_dropped`: Number of replicates dropped
+#'   * `all_outliers`: Logical, TRUE if all replicates were outliers
+#'   * `qc_info`: QC details for provenance
+#'
+#' @noRd
+average_group <- function(group_data,
+                          group_id,
+                          by,
+                          predictor_cols,
+                          meta_cols,
+                          quality_check,
+                          threshold,
+                          on_all_outliers) {
+
+  n_reps <- nrow(group_data)
+
+  ## Initialize return values ------------------------------------------------
+
+  n_dropped <- 0
+  all_outliers <- FALSE
+  qc_info <- NULL
+  rows_to_average <- seq_len(n_reps)
+
+  ## -------------------------------------------------------------------------
+  ## Quality check (if enabled and n >= 2)
+  ## -------------------------------------------------------------------------
+
+  if (quality_check && n_reps >= 2) {
+
+    ## Extract predictor matrix ----------------------------------------------
+
+    predictor_matrix <- as.matrix(group_data[, predictor_cols, drop = FALSE])
+
+    ## Compute quality -------------------------------------------------------
+
+    qc <- compute_replicate_quality(predictor_matrix, threshold)
+    qc_info <- qc
+
+    ## Handle outliers -------------------------------------------------------
+
+    if (length(qc$outliers) > 0) {
+
+      if (qc$all_fail) {
+
+        ## All replicates are outliers ---------------------------------------
+
+        all_outliers <- TRUE
+
+        if (on_all_outliers == "drop") {
+
+          ## Drop entire sample ----------------------------------------------
+
+          return(list(
+            averaged     = NULL,
+            n_dropped    = n_reps,
+            all_outliers = TRUE,
+            qc_info      = qc_info
+          ))
+
+        } else if (on_all_outliers == "keep_best") {
+
+          ## Keep only the best replicate ------------------------------------
+
+          best_idx <- which.max(qc$mean_cors)
+          rows_to_average <- best_idx
+          n_dropped <- n_reps - 1
+
+        } else {
+
+          ## warn: keep all --------------------------------------------------
+
+          rows_to_average <- seq_len(n_reps)
+
+        }
+
+      } else {
+
+        ## Some pass, some fail: drop outliers -------------------------------
+
+        rows_to_average <- setdiff(seq_len(n_reps), qc$outliers)
+        n_dropped <- length(qc$outliers)
+
+      }
+
+    }
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Average predictors
+  ## -------------------------------------------------------------------------
+
+  rows_to_use <- group_data[rows_to_average, , drop = FALSE]
+
+  if (nrow(rows_to_use) == 1) {
+
+    ## Single row: just take values ------------------------------------------
+
+    averaged_predictors <- rows_to_use[, predictor_cols, drop = FALSE]
+
+  } else {
+
+    ## Multiple rows: compute column means -----------------------------------
+
+    averaged_predictors <- tibble::as_tibble(
+      lapply(rows_to_use[, predictor_cols, drop = FALSE], mean, na.rm = TRUE)
+    )
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Handle metadata
+  ## -------------------------------------------------------------------------
+
+  ## Start with group ID -----------------------------------------------------
+
+  result <- tibble::tibble(!!by := group_id)
+
+  ## Check each meta column for uniformity -----------------------------------
+
+  for (col in meta_cols) {
+
+    col_values <- group_data[[col]]
+
+    if (check_uniformity(col_values)) {
+
+      result[[col]] <- col_values[1]
+
+    }
+
+    ## Non-uniform: column not added (will be noted in provenance) -----------
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Combine
+  ## -------------------------------------------------------------------------
+
+  result <- dplyr::bind_cols(result, averaged_predictors)
+
+  list(
+    averaged     = result,
+    n_dropped    = n_dropped,
+    all_outliers = all_outliers,
+    qc_info      = qc_info
+  )
+
+}
+
+
+## ---------------------------------------------------------------------------
+## check_uniformity() — Check if values are uniform
+## ---------------------------------------------------------------------------
+
+#' Check if all values in a vector are the same
+#'
+#' @param values Vector of values to check.
+#'
+#' @return Logical. TRUE if all values are identical (NA-aware).
+#'
+#' @noRd
+check_uniformity <- function(values) {
+
+  ## All NA is considered uniform --------------------------------------------
+
+  if (all(is.na(values))) {
+
+    return(TRUE)
+
+  }
+
+  ## Remove NAs and check uniqueness -----------------------------------------
+
+  non_na <- values[!is.na(values)]
+
+  if (length(non_na) == 0) {
+
+    return(TRUE)
+
+  }
+
+  length(unique(non_na)) == 1
+
+}

--- a/tests/testthat/test-pipeline-average.R
+++ b/tests/testthat/test-pipeline-average.R
@@ -1,0 +1,660 @@
+## ---------------------------------------------------------------------------
+## Tests for pipeline-average.R: average() function
+## ---------------------------------------------------------------------------
+
+library(testthat)
+library(horizons)
+
+
+## ---------------------------------------------------------------------------
+## Helper: Create horizons_data for testing
+## ---------------------------------------------------------------------------
+
+#' Create horizons_data object with replicate spectra for testing
+#'
+#' @param n_samples Number of unique samples.
+#' @param n_reps Number of replicates per sample.
+#' @param n_wavelengths Number of wavelength columns.
+#' @param add_outlier Logical. Add an outlier replicate to sample 1.
+#' @param all_outliers Logical. Make all replicates of sample 1 outliers.
+#' @param add_meta Logical. Add metadata columns.
+#' @param uniform_meta Logical. Make metadata uniform within samples.
+#' @return A horizons_data object.
+#' @noRd
+make_test_hd_average <- function(n_samples      = 3,
+                                 n_reps         = 3,
+                                 n_wavelengths  = 10,
+                                 add_outlier    = FALSE,
+                                 all_outliers   = FALSE,
+                                 add_meta       = FALSE,
+                                 uniform_meta   = TRUE) {
+
+  set.seed(42)
+
+  ## Build sample IDs and filenames ------------------------------------------
+
+  sample_ids <- rep(paste0("S", seq_len(n_samples)), each = n_reps)
+  filenames <- paste0(sample_ids, "_rep", rep(seq_len(n_reps), n_samples))
+  n_total <- n_samples * n_reps
+
+  ## Build spectral data (correlated within samples) -------------------------
+
+  wn_cols <- paste0("wn_", seq_len(n_wavelengths) * 100)
+
+  ## Base spectra per sample (rows = samples)
+  base_spectra <- matrix(
+    runif(n_samples * n_wavelengths, 0.5, 1.5),
+    nrow = n_samples, ncol = n_wavelengths
+  )
+
+  ## Replicate with small noise
+  spectra_data <- matrix(nrow = n_total, ncol = n_wavelengths)
+
+  for (i in seq_len(n_samples)) {
+
+    for (j in seq_len(n_reps)) {
+
+      row_idx <- (i - 1) * n_reps + j
+      spectra_data[row_idx, ] <- base_spectra[i, ] + rnorm(n_wavelengths, 0, 0.001)
+
+    }
+
+  }
+
+  ## Add outlier if requested ------------------------------------------------
+
+  if (add_outlier && !all_outliers) {
+
+    ## Make first replicate of first sample an outlier
+    ## Use completely different pattern (inverted + offset) to ensure low correlation
+    spectra_data[1, ] <- 2 - base_spectra[1, ] + rnorm(n_wavelengths, 0, 0.01)
+
+  }
+
+  if (all_outliers) {
+
+    ## Make all replicates of first sample outliers (uncorrelated with each other)
+    for (j in seq_len(n_reps)) {
+
+      ## Each replicate gets a completely random pattern
+      spectra_data[j, ] <- runif(n_wavelengths, 0, 2)
+
+    }
+
+  }
+
+  ## Build analysis tibble ---------------------------------------------------
+
+  analysis <- tibble::tibble(
+    sample_id = sample_ids,
+    filename  = filenames
+  )
+
+  ## Add metadata if requested -----------------------------------------------
+
+  if (add_meta) {
+
+    if (uniform_meta) {
+
+      ## Uniform within samples
+      analysis$project <- rep(paste0("PROJ", seq_len(n_samples)), each = n_reps)
+      analysis$site <- rep(c("SiteA", "SiteB", "SiteC")[seq_len(n_samples)], each = n_reps)
+
+    } else {
+
+      ## Non-uniform (different per replicate)
+      analysis$project <- paste0("PROJ", seq_len(n_total))
+      analysis$rep_num <- rep(seq_len(n_reps), n_samples)
+
+    }
+
+  }
+
+  ## Add spectral columns ----------------------------------------------------
+
+  for (i in seq_len(n_wavelengths)) {
+
+    analysis[[wn_cols[i]]] <- spectra_data[, i]
+
+  }
+
+  ## Build role_map ----------------------------------------------------------
+
+  meta_vars <- intersect(c("filename", "project", "site", "rep_num"), names(analysis))
+
+  role_map <- tibble::tibble(
+    variable = c("sample_id", meta_vars, wn_cols),
+    role     = c("id", rep("meta", length(meta_vars)), rep("predictor", n_wavelengths))
+  )
+
+  ## Build horizons_data -----------------------------------------------------
+
+  obj <- list(
+    data = list(
+      analysis     = analysis,
+      role_map     = role_map,
+      n_rows       = n_total,
+      n_predictors = n_wavelengths,
+      n_covariates = 0
+    ),
+    provenance = list(
+      spectra_source   = "test",
+      spectra_type     = "opus",
+      created          = Sys.time(),
+      horizons_version = utils::packageVersion("horizons"),
+      schema_version   = 1L,
+      aggregation_by   = NULL
+    )
+  )
+
+  class(obj) <- c("horizons_data", "list")
+  obj
+
+}
+
+
+## ---------------------------------------------------------------------------
+## average() — Basic functionality
+## ---------------------------------------------------------------------------
+
+test_that("average() reduces rows to number of unique samples", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 3, n_reps = 3)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_s3_class(result, "horizons_data")
+  expect_equal(nrow(result$data$analysis), 3)
+  expect_equal(result$data$analysis$sample_id, c("S1", "S2", "S3"))
+
+})
+
+test_that("average() computes mean of predictor columns", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 1, n_reps = 3, n_wavelengths = 2)
+
+  ## Get original values for first wavelength column
+  wn_col <- "wn_100"
+  original_values <- hd$data$analysis[[wn_col]]
+  expected_mean <- mean(original_values)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_equal(result$data$analysis[[wn_col]], expected_mean, tolerance = 1e-10)
+
+})
+
+test_that("average() works with single replicate groups", {
+
+
+  ## Arrange ---------------------------------------------------------------
+
+  ## Create data with 1 replicate per sample
+  hd <- make_test_hd_average(n_samples = 3, n_reps = 1)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Should pass through unchanged (except filename column)
+  expect_equal(nrow(result$data$analysis), 3)
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Quality control
+## ---------------------------------------------------------------------------
+
+test_that("average() removes outlier replicate when QC enabled", {
+
+ ## Arrange ---------------------------------------------------------------
+
+  ## With iterative removal, the outlier is removed first, then the good
+  ## replicates pass easily with the default threshold
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_outlier = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  ## Default threshold works now thanks to iterative removal
+  result <- average(hd, quality_check = TRUE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Should still have 2 samples
+  expect_equal(nrow(result$data$analysis), 2)
+
+  ## Provenance should show 1 dropped replicate (the outlier from sample 1)
+  expect_equal(result$provenance$average$n_replicates_dropped, 1)
+
+})
+
+test_that("average() with quality_check=FALSE keeps all replicates", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_outlier = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Provenance should show no dropped replicates
+  expect_equal(result$provenance$average$n_replicates_dropped, 0)
+
+})
+
+test_that("average() single replicate groups skip QC", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 3, n_reps = 1)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = TRUE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_equal(nrow(result$data$analysis), 3)
+  expect_equal(result$provenance$average$n_replicates_dropped, 0)
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — All outliers handling
+## ---------------------------------------------------------------------------
+
+test_that("average() on_all_outliers='warn' keeps all and warns", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, all_outliers = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  expect_warning(
+    result <- average(hd, quality_check = TRUE, on_all_outliers = "warn", verbose = FALSE),
+    "All replicates failed"
+  )
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Sample 1 should still be in results
+  expect_true("S1" %in% result$data$analysis$sample_id)
+  expect_equal(length(result$provenance$average$samples_all_outliers), 1)
+
+})
+
+test_that("average() on_all_outliers='drop' removes sample", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, all_outliers = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = TRUE, on_all_outliers = "drop", verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Sample 1 should be dropped
+  expect_false("S1" %in% result$data$analysis$sample_id)
+  expect_equal(nrow(result$data$analysis), 1)
+  expect_equal(result$provenance$average$samples_dropped, "S1")
+
+})
+
+test_that("average() on_all_outliers='keep_best' keeps highest correlation replicate", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, all_outliers = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = TRUE, on_all_outliers = "keep_best", verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Sample 1 should still exist (with 1 replicate)
+  expect_true("S1" %in% result$data$analysis$sample_id)
+
+  ## Should have dropped 2 replicates from S1
+  expect_equal(result$provenance$average$n_replicates_dropped, 2)
+
+})
+
+test_that("average() errors when all samples dropped", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  ## Single sample with all outliers
+  hd <- make_test_hd_average(n_samples = 1, n_reps = 3, all_outliers = TRUE)
+
+  ## Act & Assert ----------------------------------------------------------
+
+  expect_error(
+    average(hd, quality_check = TRUE, on_all_outliers = "drop", verbose = FALSE),
+    "All samples dropped"
+  )
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Metadata handling
+## ---------------------------------------------------------------------------
+
+test_that("average() preserves uniform metadata", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_meta = TRUE, uniform_meta = TRUE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_true("project" %in% names(result$data$analysis))
+  expect_true("site" %in% names(result$data$analysis))
+  expect_equal(result$data$analysis$project, c("PROJ1", "PROJ2"))
+
+})
+
+test_that("average() drops non-uniform metadata", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_meta = TRUE, uniform_meta = FALSE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## rep_num should be dropped (different per replicate)
+  expect_false("rep_num" %in% names(result$data$analysis))
+
+  ## project should be dropped (different per row)
+  expect_false("project" %in% names(result$data$analysis))
+
+  ## Should be tracked in provenance
+  expect_true("rep_num" %in% result$provenance$average$meta_columns_dropped)
+
+})
+
+test_that("average() always drops filename column", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_false("filename" %in% names(result$data$analysis))
+  expect_true("filename" %in% result$provenance$average$meta_columns_dropped)
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Provenance
+## ---------------------------------------------------------------------------
+
+test_that("average() records provenance correctly", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 3, n_reps = 4)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = TRUE, correlation_threshold = 0.99, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  prov <- result$provenance$average
+
+  expect_equal(prov$by, "sample_id")
+  expect_true(prov$quality_check)
+  expect_equal(prov$correlation_threshold, 0.99)
+  expect_equal(prov$on_all_outliers, "warn")
+  expect_equal(prov$n_groups, 3)
+  expect_equal(prov$n_replicates_before, 12)
+  expect_equal(prov$n_replicates_after, 3)
+  expect_s3_class(prov$applied_at, "POSIXct")
+
+})
+
+test_that("average() updates aggregation_by in provenance", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 2)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, by = "sample_id", quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_equal(result$provenance$aggregation_by, "sample_id")
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Custom grouping column
+## ---------------------------------------------------------------------------
+
+test_that("average() works with custom by column", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_meta = TRUE, uniform_meta = TRUE)
+
+  ## Use project as grouping column (2 projects)
+  ## Note: with our test data, project maps 1:1 with sample_id
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, by = "project", quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_equal(nrow(result$data$analysis), 2)
+  expect_true("project" %in% names(result$data$analysis))
+  expect_equal(result$provenance$average$by, "project")
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Input validation
+## ---------------------------------------------------------------------------
+
+test_that("average() errors on non-horizons_data input", {
+
+  expect_error(
+    average(data.frame(x = 1)),
+    "must be a horizons_data"
+  )
+
+})
+
+test_that("average() errors when by column doesn't exist", {
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 2)
+
+  expect_error(
+    average(hd, by = "nonexistent"),
+    "not found"
+  )
+
+})
+
+test_that("average() errors on invalid quality_check", {
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 2)
+
+  expect_error(
+    average(hd, quality_check = "yes"),
+    "must be TRUE or FALSE"
+  )
+
+})
+
+test_that("average() errors on invalid correlation_threshold", {
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 2)
+
+  expect_error(
+    average(hd, correlation_threshold = 1.5),
+    "between 0 and 1"
+  )
+
+  expect_error(
+    average(hd, correlation_threshold = -0.1),
+    "between 0 and 1"
+  )
+
+})
+
+
+## ---------------------------------------------------------------------------
+## average() — Role map updates
+## ---------------------------------------------------------------------------
+
+test_that("average() updates role_map to remove dropped columns", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  hd <- make_test_hd_average(n_samples = 2, n_reps = 3, add_meta = TRUE, uniform_meta = FALSE)
+
+  ## Act -------------------------------------------------------------------
+
+  result <- average(hd, quality_check = FALSE, verbose = FALSE)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Dropped columns should not be in role_map
+  expect_false("filename" %in% result$data$role_map$variable)
+  expect_false("rep_num" %in% result$data$role_map$variable)
+
+  ## Retained columns should still be there
+  expect_true("sample_id" %in% result$data$role_map$variable)
+  expect_true(any(grepl("^wn_", result$data$role_map$variable)))
+
+})
+
+
+## ---------------------------------------------------------------------------
+## Helper function tests
+## ---------------------------------------------------------------------------
+
+test_that("compute_replicate_quality() identifies outliers via iterative removal", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  set.seed(123)
+
+  ## With iterative removal:
+  ## 1. First pass: bad spectrum has lowest mean cor, gets removed
+  ## 2. Second pass: good spectra now correlate ~1.0 with each other, all pass
+  ## Result: only the bad spectrum is flagged as outlier
+
+  ## Base spectrum (use a clear pattern)
+  base <- c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+  ## 3 highly correlated spectra (same pattern, tiny noise)
+  good_spectra <- matrix(nrow = 3, ncol = 10)
+  good_spectra[1, ] <- base + rnorm(10, 0, 0.001)
+  good_spectra[2, ] <- base + rnorm(10, 0, 0.001)
+  good_spectra[3, ] <- base + rnorm(10, 0, 0.001)
+
+  ## 1 outlier (inverted pattern - will have negative correlation)
+  bad_spectrum <- rev(base) + rnorm(10, 0, 0.001)
+
+  all_spectra <- rbind(good_spectra, bad_spectrum)
+
+  ## Act -------------------------------------------------------------------
+
+  ## With iterative removal and high threshold, bad one is removed first,
+
+  ## then good ones pass easily
+  qc <- horizons:::compute_replicate_quality(all_spectra, threshold = 0.99)
+
+  ## Assert ----------------------------------------------------------------
+
+  ## Only spectrum 4 should be flagged as outlier
+  expect_equal(qc$outliers, 4L)
+  expect_false(qc$all_fail)
+
+  ## Good spectra (1-3) should have high mean correlations after outlier removal
+  expect_true(all(qc$mean_cors[1:3] > 0.99, na.rm = TRUE))
+
+  ## Outlier's mean_cors is NA (it was removed)
+  expect_true(is.na(qc$mean_cors[4]))
+
+})
+
+test_that("compute_replicate_quality() returns empty for n=1", {
+
+  ## Arrange ---------------------------------------------------------------
+
+  single_spectrum <- matrix(c(1, 2, 3), nrow = 1)
+
+  ## Act -------------------------------------------------------------------
+
+  qc <- horizons:::compute_replicate_quality(single_spectrum, threshold = 0.99)
+
+  ## Assert ----------------------------------------------------------------
+
+  expect_length(qc$outliers, 0)
+  expect_false(qc$all_fail)
+
+})
+
+test_that("check_uniformity() correctly identifies uniform values", {
+
+  ## All same
+  expect_true(horizons:::check_uniformity(c("A", "A", "A")))
+
+  ## All NA
+  expect_true(horizons:::check_uniformity(c(NA, NA, NA)))
+
+  ## Mixed with NA (uniform non-NA)
+  expect_true(horizons:::check_uniformity(c("A", NA, "A")))
+
+  ## Not uniform
+  expect_false(horizons:::check_uniformity(c("A", "B", "A")))
+
+  ## Single value
+  expect_true(horizons:::check_uniformity("A"))
+
+})

--- a/tests/testthat/test-pipeline-average.R
+++ b/tests/testthat/test-pipeline-average.R
@@ -340,6 +340,11 @@ test_that("average() on_all_outliers='keep_best' keeps highest correlation repli
   ## Should have dropped 2 replicates from S1
   expect_equal(result$provenance$average$n_replicates_dropped, 2)
 
+  ## Verify keep_best retained the QC survivor (not an all-NA artifact)
+  s1_result <- result$data$analysis[result$data$analysis$sample_id == "S1", ]
+  wn_cols   <- grep("^wn_", names(s1_result), value = TRUE)
+  expect_true(all(!is.na(s1_result[, wn_cols])))
+
 })
 
 test_that("average() errors when all samples dropped", {


### PR DESCRIPTION
## Summary
- Implements `average()` pipeline verb for aggregating replicate spectral measurements
- Rebased from closed PR #17 (auto-closed when base branch was deleted during PR review workflow)

## Test plan
- [x] 59 tests passing for pipeline-average
- [x] 80 class-core tests passing
- [x] No regressions in spectra/parse-ids tests