### PR TITLE
feat: progress bar for OPUS file reading

### DIFF
--- a/R/pipeline-spectra.R
+++ b/R/pipeline-spectra.R
@@ -461,20 +461,34 @@ load_opus_files <- function(source,
 
   ## Read all files ----------------------------------------------------------
 
-  spectra_list <- lapply(file_paths, function(fp) {
+  n_files      <- length(file_paths)
+  n_failed     <- 0L
+  spectra_list <- vector("list", n_files)
 
-    tryCatch({
+  cli::cli_progress_bar(
+    format = "Reading {n_files} OPUS files {cli::pb_bar} {cli::pb_current}/{n_files} ({cli::pb_percent})",
+    total  = n_files
+  )
 
-      suppressWarnings(opusreader2::read_opus(fp))
+  for (i in seq_along(file_paths)) {
+
+    spectra_list[[i]] <- tryCatch({
+
+      suppressWarnings(opusreader2::read_opus(file_paths[[i]]))
 
     }, error = function(e) {
 
-      cli::cli_warn("Failed to read {.path {fp}}: {e$message}")
+      n_failed <<- n_failed + 1L
+      cli::cli_warn("Failed to read {.path {file_paths[[i]]}}: {e$message}")
       return(NULL)
 
     })
 
-  })
+    cli::cli_progress_update()
+
+  }
+
+  cli::cli_progress_done()
 
   ## Filter out failures -----------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds `cli::cli_progress_bar()` to the OPUS file reading loop in `spectra_from_path()`
- Shows file-by-file progress during loading (e.g., "Reading 338 OPUS files ████████░░ 250/338 (74%)")
- Replaces silent `lapply` with explicit `for` loop + progress updates

## Test plan
- [x] 48 spectra tests pass
- [x] Progress bar renders correctly for multi-file directories
- [x] Single-file and tibble paths unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress bar to OPUS file loading process
  * Enhanced error handling with detailed per-file warnings and reporting when files fail to load
  * Improved robustness: processing continues through failed files and validates successful completion before proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->