### PR TITLE
fix: route predict()'s point-prediction call through the error cascade

### DIFF
--- a/R/pipeline-predict.R
+++ b/R/pipeline-predict.R
@@ -355,7 +355,20 @@ predict_one_config <- function(object, config_id, new_spectra, interval) {
   ## Point prediction (transformed scale → back-transform ONCE to original)
   ## -------------------------------------------------------------------------
 
-  point_trans <- stats::predict(workflow, new_data = new_spectra)$.pred
+  ## Routed through the safely_execute -> handle_results cascade: a butchered
+  ## workflow can fail at predict time (e.g. recipe re-introspection), and the
+  ## raw parsnip/workflows error carries no horizons context. Wrap so the
+  ## failure names the offending config.
+  pred_safe <- safely_execute(
+    stats::predict(workflow, new_data = new_spectra),
+    log_error          = FALSE,
+    capture_conditions = TRUE
+  )
+
+  point_trans <- handle_results(
+    pred_safe,
+    error_title = paste0("Prediction failed for config '", config_id, "'.")
+  )$.pred
 
   point_pred <- if (needs_back_transformation(transformation)) {
 


### PR DESCRIPTION
One-spot follow-up to PR #30. The core `stats::predict()` in `predict_one_config()` ran bare — a butchered-workflow failure surfaced as a raw parsnip error with no horizons context. Wrapped in `safely_execute -> handle_results` so the failure names the offending config, matching the cascade the rest of the fit/predict stack (and predict's own conformal path) already use. Predict tests green; happy path untouched.