### PR TITLE
feat(ensemble): implement predict.horizons_ensemble() point predictions

### DIFF
--- a/R/ensemble-helpers.R
+++ b/R/ensemble-helpers.R
@@ -588,40 +588,62 @@ build_ensemble_contract <- function(method,
 }
 
 ## ---------------------------------------------------------------------------
-## predict.horizons_ensemble() — skeleton
+## predict.horizons_ensemble()
 ## ---------------------------------------------------------------------------
 
-#' Predict from a Fitted Ensemble (skeleton)
+#' Predict Soil Properties from a Fitted Ensemble
 #'
 #' @description
-#' Predicts new spectra from a fitted ensemble. Each member predicts via the
-#' same per-config primitive `predict.horizons_fit()` uses
-#' (`predict_one_config()` — predict once, back-transform once), and the
-#' member predictions are combined by the meta-learner stored in
-#' `object$ensemble`. The combination differs by method: `penalized`/`weighted`
-#' take a (weighted) linear combination of member predictions; `xgb` feeds the
-#' member predictions through the boosted meta-model.
+#' Generates stacked-ensemble predictions for new spectra. Every member predicts
+#' via the same per-config primitive [predict.horizons_fit()] uses
+#' (`predict_one_config()` — predict once, back-transform once), and the member
+#' predictions are combined by the meta-learner stored in `object$ensemble`. The
+#' combination differs by method: `weighted` takes a fixed weighted average of
+#' member predictions; `penalized` and `xgb` feed the member predictions through
+#' the fitted meta-model.
 #'
-#' This is a Phase-1 skeleton: the combination logic lands with the engines,
-#' which populate `object$ensemble$model` and `$weights`. It establishes the
-#' method signature and the contract reference, and errors clearly until an
-#' ensemble has actually been built.
-#'
-#' @param object A `horizons_ensemble` object.
-#' @param new_data Spectra to predict, on the training axis (same requirement
-#'   as [predict.horizons_fit()]).
-#' @param interval Logical. Return ensemble prediction intervals when Phase-2
-#'   UQ is present (`object$ensemble$uq`). Default `TRUE`.
+#' @param object A `horizons_ensemble` object (the output of [ensemble()]).
+#' @param new_data Spectra to predict. Either a `horizons_data` object or a
+#'   tibble/data.frame whose predictor (wavelength) columns match the training
+#'   schema. **The spectra must already be on the training axis** — the same
+#'   requirement as [predict.horizons_fit()]; see its Details for the axis-
+#'   alignment limitation.
+#' @param interval Logical. Return ensemble prediction intervals when ensemble
+#'   uncertainty quantification is available (`object$ensemble$uq`). Default
+#'   `TRUE`. Ensemble UQ is not computed in this release, so `interval = TRUE`
+#'   currently returns point predictions with a one-time note.
 #' @param ... Unused; present for S3 method consistency.
 #'
-#' @return A tibble of ensemble predictions (skeleton: not yet implemented).
+#' @return A tibble, one row per sample:
+#'   \describe{
+#'     \item{sample_id}{Sample identifier from `new_data`.}
+#'     \item{.pred}{Ensemble point prediction, original response scale.}
+#'   }
+#'   Interval columns (`.pred_lower`, `.pred_upper`, `.interval_width`) are
+#'   appended when ensemble UQ is present and `interval = TRUE`.
 #'
-#' @keywords internal
+#' @details
+#' All ensemble members must predict successfully. A member that fails to
+#' predict on `new_data` aborts the call naming the offending config — the
+#' meta-learner's combination is only valid over the exact member set it was
+#' trained on, so dropping a member would silently change what is being
+#' predicted.
+#'
+#' @examples
+#' \dontrun{
+#' ens <- ensemble(fit(evaluated, n_best = 5))
+#' predict(ens, new_spectra)
+#' }
+#'
 #' @exportS3Method stats::predict horizons_ensemble
 predict.horizons_ensemble <- function(object,
                                       new_data,
                                       interval = TRUE,
                                       ...) {
+
+  ## -------------------------------------------------------------------------
+  ## Step 0: Preflight
+  ## -------------------------------------------------------------------------
 
   if (!inherits(object, "horizons_ensemble")) {
 
@@ -638,9 +660,185 @@ predict.horizons_ensemble <- function(object,
 
   }
 
-  cli::cli_abort(c(
-    "{.fn predict.horizons_ensemble} is not implemented yet.",
-    "i" = "The combination logic lands with the meta-learner engines."
-  ))
+  ## -------------------------------------------------------------------------
+  ## Step 1: Resolve new_data, then validate it carries the training axis
+  ## -------------------------------------------------------------------------
+
+  new_spectra <- resolve_new_data(new_data)
+
+  check_predictor_schema(object, new_spectra)
+
+  ## -------------------------------------------------------------------------
+  ## Step 2: Resolve the authoritative member set
+  ## -------------------------------------------------------------------------
+
+  ## The members the meta-learner actually trained on are exactly the rows of
+  ## the weights tibble. Read them directly rather than re-deriving via
+  ## gather_members(), which intersects train-time slots (cv_predictions) and
+  ## could disagree with what the fitted meta-model saw.
+  members <- object$ensemble$weights$member
+
+  if (is.null(members) || length(members) < 2) {
+
+    cli::cli_abort(c(
+      "The fitted ensemble carries no member set.",
+      "i" = "{.fn ensemble} should record at least two members in its weights."
+    ))
+
+  }
+
+  ## -------------------------------------------------------------------------
+  ## Step 3: Every member predicts new_data (long frame, original scale)
+  ## -------------------------------------------------------------------------
+
+  member_pred <- predict_members(object, members, new_spectra)
+
+  ## -------------------------------------------------------------------------
+  ## Step 4: Combine member predictions by the meta-learner (per method)
+  ## -------------------------------------------------------------------------
+
+  method <- object$ensemble$method
+
+  point <- switch(
+    method,
+
+    weighted = combine_ensemble_weighted(member_pred, object$ensemble$weights),
+
+    penalized = ,
+    xgb       = combine_ensemble_metamodel(member_pred, members,
+                                           object$ensemble$model),
+
+    cli::cli_abort(c(
+      "Unknown ensemble method {.val {method}}.",
+      "i" = "Expected one of {.val {c('weighted', 'penalized', 'xgb')}}."
+    ))
+  )
+
+  ## -------------------------------------------------------------------------
+  ## Step 5: Intervals (only when ensemble UQ is available) + assemble output
+  ## -------------------------------------------------------------------------
+
+  ## Mirror the single-model seam (predict_one_config): point predictions are
+  ## complete here; intervals are a pure append when a UQ bundle exists. Ensemble
+  ## UQ is not computed in this release, so the bundle is absent and we degrade
+  ## to point-only with a one-time note.
+  uq <- object$ensemble$uq
+
+  if (!isTRUE(interval) || is.null(uq)) {
+
+    if (isTRUE(interval) && is.null(uq)) {
+
+      cli::cli_inform(c(
+        "i" = "Ensemble prediction intervals are not available; \\
+               returning point predictions."
+      ))
+
+    }
+
+    return(point)
+
+  }
+
+  interval_cols <- predict_intervals(
+    uq          = uq,
+    point_pred  = point$.pred,
+    new_spectra = new_spectra
+  )
+
+  if (is.null(interval_cols)) {
+
+    return(point)
+
+  }
+
+  dplyr::bind_cols(point, interval_cols)
+
+}
+
+## ---------------------------------------------------------------------------
+## combine_ensemble_weighted() — weighted-average combine (silent helper)
+## ---------------------------------------------------------------------------
+
+#' Combine member predictions by the ensemble weights
+#'
+#' The predict-time generalization of the `weighted` engine's train-time
+#' combine (`fit_ensemble_weighted()`): join the per-member weights, then take
+#' the weighted sum per sample. Floored at zero — soil properties are
+#' non-negative.
+#'
+#' @param member_pred Long tibble from [predict_members()] (`config_id`,
+#'   `sample_id`, `.pred`).
+#' @param weights The ensemble weights tibble (`member`, `coef`).
+#' @return A tibble: `sample_id`, `.pred` (ensemble point prediction).
+#' @keywords internal
+#' @noRd
+combine_ensemble_weighted <- function(member_pred, weights) {
+
+  out <- member_pred %>%
+    dplyr::left_join(weights, by = c("config_id" = "member")) %>%
+    dplyr::group_by(.data$sample_id) %>%
+    dplyr::summarise(.pred = sum(.data$.pred * .data$coef),
+                     .groups = "drop")
+
+  out$.pred <- floor_at_zero(out$.pred)
+
+  out
+
+}
+
+## ---------------------------------------------------------------------------
+## combine_ensemble_metamodel() — meta-model combine (silent helper)
+## ---------------------------------------------------------------------------
+
+#' Combine member predictions through a fitted meta-model
+#'
+#' The predict-time generalization of the `penalized`/`xgb` engines' train-time
+#' combine: widen the member predictions into the `member_<config_id>` matrix
+#' the meta-model trained on, then run them THROUGH the fitted meta-workflow.
+#' Floored at zero.
+#'
+#' The wide-frame columns are selected explicitly from the trained-on member
+#' set (not from whatever the pivot happens to produce), and a missing member
+#' column aborts — the meta-model's combination is only valid over the exact
+#' member set it saw, so an incomplete frame must fail loudly rather than
+#' silently mispredict.
+#'
+#' @param member_pred Long tibble from [predict_members()].
+#' @param members Character vector of the trained-on member `config_id`s.
+#' @param model The fitted meta-workflow (`object$ensemble$model`).
+#' @return A tibble: `sample_id`, `.pred` (ensemble point prediction).
+#' @keywords internal
+#' @noRd
+combine_ensemble_metamodel <- function(member_pred, members, model) {
+
+  member_cols <- paste0("member_", members)
+
+  wide <- member_pred %>%
+    dplyr::select("sample_id", "config_id", ".pred") %>%
+    tidyr::pivot_wider(names_from   = "config_id",
+                       values_from  = ".pred",
+                       names_prefix = "member_")
+
+  missing <- setdiff(member_cols, names(wide))
+
+  if (length(missing) > 0) {
+
+    cli::cli_abort(c(
+      "Member prediction{?s} missing for {length(missing)} ensemble member{?s}.",
+      "x" = "Absent: {.val {sub('^member_', '', missing)}}",
+      "i" = "Every ensemble member must predict {.arg new_data}."
+    ))
+
+  }
+
+  combined <- stats::predict(
+    model,
+    new_data = wide[, member_cols, drop = FALSE]
+  )$.pred
+
+  tibble::tibble(
+    sample_id = wide$sample_id,
+    .pred     = floor_at_zero(combined)
+  )
 
 }

--- a/R/ensemble-helpers.R
+++ b/R/ensemble-helpers.R
@@ -770,12 +770,31 @@ predict.horizons_ensemble <- function(object,
 #'   `sample_id`, `.pred`).
 #' @param weights The ensemble weights tibble (`member`, `coef`).
 #' @return A tibble: `sample_id`, `.pred` (ensemble point prediction).
-#' @keywords internal
 #' @noRd
 combine_ensemble_weighted <- function(member_pred, weights) {
 
-  out <- member_pred %>%
-    dplyr::left_join(weights, by = c("config_id" = "member")) %>%
+  joined <- member_pred %>%
+    dplyr::left_join(weights, by = c("config_id" = "member"))
+
+  ## A member with predictions but no matching weight leaves `coef` NA, which
+  ## would propagate through sum() to an NA ensemble prediction returned as a
+  ## valid tibble. predict_members() guarantees the member set matches, so this
+  ## is unreachable on the normal path — but the join is the one spot a future
+  ## member-set drift could corrupt silently, so fail loud here. This mirrors the
+  ## explicit member-presence gate in combine_ensemble_metamodel().
+  if (anyNA(joined$coef)) {
+
+    unmatched <- unique(joined$config_id[is.na(joined$coef)])
+
+    cli::cli_abort(c(
+      "Weighted combine has no weight for {length(unmatched)} member{?s}.",
+      "x" = "Unweighted: {.val {unmatched}}",
+      "i" = "The member set must match the ensemble weights."
+    ))
+
+  }
+
+  out <- joined %>%
     dplyr::group_by(.data$sample_id) %>%
     dplyr::summarise(.pred = sum(.data$.pred * .data$coef),
                      .groups = "drop")
@@ -807,7 +826,6 @@ combine_ensemble_weighted <- function(member_pred, weights) {
 #' @param members Character vector of the trained-on member `config_id`s.
 #' @param model The fitted meta-workflow (`object$ensemble$model`).
 #' @return A tibble: `sample_id`, `.pred` (ensemble point prediction).
-#' @keywords internal
 #' @noRd
 combine_ensemble_metamodel <- function(member_pred, members, model) {
 

--- a/R/pipeline-predict.R
+++ b/R/pipeline-predict.R
@@ -420,6 +420,58 @@ predict_one_config <- function(object, config_id, new_spectra, interval) {
 }
 
 ## ---------------------------------------------------------------------------
+## predict_members() — every ensemble member predicts new_data (silent helper)
+## ---------------------------------------------------------------------------
+
+#' Predict new spectra from each ensemble member
+#'
+#' Runs every member config through the same per-config primitive the single
+#' fit path uses ([predict_one_config()] — predict once, back-transform once)
+#' and stacks the results into one long frame. This is the predict-time analog
+#' of the train-time `predict_members_on_test()`: same structure, minus the
+#' truth column (new data carries no outcome).
+#'
+#' Members are predicted point-only (`interval = FALSE`); the ensemble's own
+#' uncertainty is conformalized on the meta-learner's residuals downstream, not
+#' assembled from member intervals.
+#'
+#' @param object A `horizons_ensemble` (or any object carrying
+#'   `models$workflows`).
+#' @param members Character vector of member `config_id`s to predict.
+#' @param new_spectra Tibble from [resolve_new_data()] (sample_id + predictors).
+#' @return A long tibble: `config_id`, `sample_id`, `.pred` (original scale),
+#'   one block per member.
+#' @keywords internal
+#' @noRd
+predict_members <- function(object, members, new_spectra) {
+
+  ## sample_id is the join key for every downstream combine (weighted average
+  ## groups on it; the wide pivot keys rows on it). A duplicate would silently
+  ## fan out each member's predictions and corrupt the combination, so assert
+  ## uniqueness loudly here — the predict-time mirror of the train-time gate in
+  ## predict_members_on_test().
+  if (anyDuplicated(new_spectra$sample_id)) {
+
+    cli::cli_abort(c(
+      "{.field sample_id}s in {.arg new_data} are not unique.",
+      "x" = "Duplicate keys would fan out the member-prediction combine.",
+      "i" = "Expected one row per sample."
+    ))
+
+  }
+
+  dplyr::bind_rows(lapply(members, function(m) {
+
+    pc <- predict_one_config(object, config_id = m, new_spectra = new_spectra,
+                             interval = FALSE)
+
+    tibble::tibble(config_id = m, sample_id = pc$sample_id, .pred = pc$.pred)
+
+  }))
+
+}
+
+## ---------------------------------------------------------------------------
 ## predict_intervals() — conformal prediction intervals for one config
 ## ---------------------------------------------------------------------------
 

--- a/man/predict.horizons_ensemble.Rd
+++ b/man/predict.horizons_ensemble.Rd
@@ -2,36 +2,55 @@
 % Please edit documentation in R/ensemble-helpers.R
 \name{predict.horizons_ensemble}
 \alias{predict.horizons_ensemble}
-\title{Predict from a Fitted Ensemble (skeleton)}
+\title{Predict Soil Properties from a Fitted Ensemble}
 \usage{
 \method{predict}{horizons_ensemble}(object, new_data, interval = TRUE, ...)
 }
 \arguments{
-\item{object}{A \code{horizons_ensemble} object.}
+\item{object}{A \code{horizons_ensemble} object (the output of \code{\link[=ensemble]{ensemble()}}).}
 
-\item{new_data}{Spectra to predict, on the training axis (same requirement
-as \code{\link[=predict.horizons_fit]{predict.horizons_fit()}}).}
+\item{new_data}{Spectra to predict. Either a \code{horizons_data} object or a
+tibble/data.frame whose predictor (wavelength) columns match the training
+schema. \strong{The spectra must already be on the training axis} — the same
+requirement as \code{\link[=predict.horizons_fit]{predict.horizons_fit()}}; see its Details for the axis-
+alignment limitation.}
 
-\item{interval}{Logical. Return ensemble prediction intervals when Phase-2
-UQ is present (\code{object$ensemble$uq}). Default \code{TRUE}.}
+\item{interval}{Logical. Return ensemble prediction intervals when ensemble
+uncertainty quantification is available (\code{object$ensemble$uq}). Default
+\code{TRUE}. Ensemble UQ is not computed in this release, so \code{interval = TRUE}
+currently returns point predictions with a one-time note.}
 
 \item{...}{Unused; present for S3 method consistency.}
 }
 \value{
-A tibble of ensemble predictions (skeleton: not yet implemented).
+A tibble, one row per sample:
+\describe{
+\item{sample_id}{Sample identifier from \code{new_data}.}
+\item{.pred}{Ensemble point prediction, original response scale.}
+}
+Interval columns (\code{.pred_lower}, \code{.pred_upper}, \code{.interval_width}) are
+appended when ensemble UQ is present and \code{interval = TRUE}.
 }
 \description{
-Predicts new spectra from a fitted ensemble. Each member predicts via the
-same per-config primitive \code{predict.horizons_fit()} uses
-(\code{predict_one_config()} — predict once, back-transform once), and the
-member predictions are combined by the meta-learner stored in
-\code{object$ensemble}. The combination differs by method: \code{penalized}/\code{weighted}
-take a (weighted) linear combination of member predictions; \code{xgb} feeds the
-member predictions through the boosted meta-model.
-
-This is a Phase-1 skeleton: the combination logic lands with the engines,
-which populate \code{object$ensemble$model} and \verb{$weights}. It establishes the
-method signature and the contract reference, and errors clearly until an
-ensemble has actually been built.
+Generates stacked-ensemble predictions for new spectra. Every member predicts
+via the same per-config primitive \code{\link[=predict.horizons_fit]{predict.horizons_fit()}} uses
+(\code{predict_one_config()} — predict once, back-transform once), and the member
+predictions are combined by the meta-learner stored in \code{object$ensemble}. The
+combination differs by method: \code{weighted} takes a fixed weighted average of
+member predictions; \code{penalized} and \code{xgb} feed the member predictions through
+the fitted meta-model.
 }
-\keyword{internal}
+\details{
+All ensemble members must predict successfully. A member that fails to
+predict on \code{new_data} aborts the call naming the offending config — the
+meta-learner's combination is only valid over the exact member set it was
+trained on, so dropping a member would silently change what is being
+predicted.
+}
+\examples{
+\dontrun{
+ens <- ensemble(fit(evaluated, n_best = 5))
+predict(ens, new_spectra)
+}
+
+}

--- a/tests/testthat/test-pipeline-ensemble.R
+++ b/tests/testthat/test-pipeline-ensemble.R
@@ -239,3 +239,206 @@ describe("ensemble() - preflight validation", {
   })
 
 })
+
+## =========================================================================
+## predict.horizons_ensemble() — output contract
+## =========================================================================
+## Predicting the held-out Split-F test set is the natural round-trip: it is
+## the same data the train-time combine scored, so predict() should reproduce
+## the stored ensemble predictions. test_F also carries truth, but predict()
+## must IGNORE it and return only sample_id + .pred (no config_id, no truth).
+
+test_set <- rsample::assessment(fitted$models$split)
+
+describe("predict.horizons_ensemble() - output contract", {
+
+  it("returns sample_id + .pred only, one row per sample, for every method", {
+
+    for (m in c("weighted", "penalized", "xgb")) {
+
+      ens <- suppressWarnings(
+        ensemble(fitted, method = m, optimize = FALSE, verbose = FALSE)
+      )
+
+      p <- predict(ens, test_set, interval = FALSE)
+
+      expect_setequal(names(p), c("sample_id", ".pred"))
+      expect_equal(nrow(p), dplyr::n_distinct(test_set$sample_id))
+      expect_false("config_id" %in% names(p))
+      expect_false(".pred_lower" %in% names(p))
+      expect_type(p$.pred, "double")
+
+    }
+
+  })
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — round-trip reproduces stored predictions
+## =========================================================================
+## The strongest correctness teeth: predicting test_F is the identical data
+## path the engine used to build $ensemble$predictions, so the predictions must
+## match to numerical precision. A double back-transform, a member-order bug, or
+## a wrong combine would all break this. optimize = FALSE keeps the meta-model
+## deterministic across the fit and the predict path.
+
+describe("predict.horizons_ensemble() - round-trips the stored predictions", {
+
+  for (m in c("weighted", "penalized", "xgb")) {
+
+    it(paste0("method = '", m, "' reproduces $ensemble$predictions on test_F"), {
+
+      ens <- suppressWarnings(
+        ensemble(fitted, method = m, optimize = FALSE, verbose = FALSE)
+      )
+
+      p      <- predict(ens, test_set, interval = FALSE)
+      stored <- ens$ensemble$predictions
+
+      joined <- dplyr::inner_join(
+        p, stored[, c("sample_id", ".pred")],
+        by = "sample_id", suffix = c("_new", "_stored")
+      )
+
+      expect_equal(nrow(joined), nrow(stored))
+      expect_equal(joined$.pred_new, joined$.pred_stored, tolerance = 1e-8)
+
+    })
+
+  }
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — weighted combine equals the documented math
+## =========================================================================
+## Pin the weighted method to its definition (sum of member .pred * coef),
+## computed independently of the function under test, so the assertion fails if
+## the implementation drifts from the documented combination.
+
+describe("predict.horizons_ensemble() - weighted combine is the documented sum", {
+
+  it("equals sum(member .pred * coef) per sample, floored at 0", {
+
+    ens <- suppressWarnings(
+      ensemble(fitted, method = "weighted", optimize = FALSE, verbose = FALSE)
+    )
+
+    members  <- ens$ensemble$weights$member
+    new_spec <- resolve_new_data(test_set)
+    mp       <- predict_members(ens, members, new_spec)
+
+    by_hand <- mp %>%
+      dplyr::left_join(ens$ensemble$weights,
+                       by = c("config_id" = "member")) %>%
+      dplyr::group_by(.data$sample_id) %>%
+      dplyr::summarise(by_hand = sum(.data$.pred * .data$coef),
+                       .groups = "drop")
+
+    by_hand$by_hand[by_hand$by_hand < 0] <- 0
+
+    p <- predict(ens, test_set, interval = FALSE)
+
+    joined <- dplyr::inner_join(p, by_hand, by = "sample_id")
+
+    expect_equal(joined$.pred, joined$by_hand, tolerance = 1e-10)
+
+  })
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — reuses the training-axis schema gate
+## =========================================================================
+
+describe("predict.horizons_ensemble() - schema gate", {
+
+  it("aborts when new_data is missing training-axis predictor columns", {
+
+    ens <- suppressWarnings(
+      ensemble(fitted, method = "weighted", optimize = FALSE, verbose = FALSE)
+    )
+
+    pred_cols <- fitted$models$predictor_schema
+    broken    <- test_set[, setdiff(names(test_set), pred_cols[1]),
+                          drop = FALSE]
+
+    expect_error(predict(ens, broken, interval = FALSE),
+                 class = "rlang_error")
+
+  })
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — interval degrades gracefully (no ensemble UQ)
+## =========================================================================
+## Ensemble UQ is not computed in this release, so interval = TRUE must return
+## point predictions with a one-time note rather than erroring. This is the hook
+## ensemble conformal UQ fills later; the point path must not change when it does.
+
+describe("predict.horizons_ensemble() - graceful interval degradation", {
+
+  ens <- suppressWarnings(
+    ensemble(fitted, method = "weighted", optimize = FALSE, verbose = FALSE)
+  )
+
+  it("interval = TRUE returns point-only with an informative message", {
+
+    expect_message(
+      p <- predict(ens, test_set, interval = TRUE),
+      regexp = "intervals are not available"
+    )
+    expect_false(".pred_lower" %in% names(p))
+
+  })
+
+  it("interval = FALSE returns point-only with no message", {
+
+    expect_no_message(predict(ens, test_set, interval = FALSE))
+
+  })
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — aborts when a member cannot predict
+## =========================================================================
+## The meta-learner's combine is only valid over the exact member set it was
+## trained on. If a member's workflow cannot predict, the call must abort naming
+## the failure rather than dropping the member and silently changing the
+## estimand. Corrupt one member's stored workflow to force the failure.
+
+describe("predict.horizons_ensemble() - aborts on a failing member", {
+
+  it("does not renormalize; aborts when a member workflow cannot predict", {
+
+    ens <- suppressWarnings(
+      ensemble(fitted, method = "weighted", optimize = FALSE, verbose = FALSE)
+    )
+
+    broken_member <- ens$ensemble$weights$member[1]
+    ens$models$workflows[[broken_member]] <- "not a workflow"
+
+    expect_error(predict(ens, test_set, interval = FALSE),
+                 class = "rlang_error")
+
+  })
+
+})
+
+## =========================================================================
+## predict.horizons_ensemble() — preflight
+## =========================================================================
+
+describe("predict.horizons_ensemble() - preflight", {
+
+  it("aborts on a non-ensemble object", {
+
+    expect_error(predict.horizons_ensemble(fitted, test_set),
+                 class = "rlang_error")
+
+  })
+
+})

--- a/tests/testthat/test-pipeline-ensemble.R
+++ b/tests/testthat/test-pipeline-ensemble.R
@@ -277,10 +277,13 @@ describe("predict.horizons_ensemble() - output contract", {
 ## =========================================================================
 ## predict.horizons_ensemble() — round-trip reproduces stored predictions
 ## =========================================================================
-## The strongest correctness teeth: predicting test_F is the identical data
-## path the engine used to build $ensemble$predictions, so the predictions must
-## match to numerical precision. A double back-transform, a member-order bug, or
-## a wrong combine would all break this. optimize = FALSE keeps the meta-model
+## A round-trip consistency check: predicting test_F is the identical data path
+## the engine used to build $ensemble$predictions, so the two must match to
+## numerical precision. This catches a double back-transform, a member-order
+## bug, a scale mismatch between predict() and the stored combine, or a wrong
+## combine. It does NOT validate original-scale accuracy or interval coverage —
+## both predict() and the stored values share the same machinery, so an error
+## common to both would survive. optimize = FALSE keeps the meta-model
 ## deterministic across the fit and the predict path.
 
 describe("predict.horizons_ensemble() - round-trips the stored predictions", {
@@ -336,7 +339,7 @@ describe("predict.horizons_ensemble() - weighted combine is the documented sum",
       dplyr::summarise(by_hand = sum(.data$.pred * .data$coef),
                        .groups = "drop")
 
-    by_hand$by_hand[by_hand$by_hand < 0] <- 0
+    by_hand$by_hand <- floor_at_zero(by_hand$by_hand)
 
     p <- predict(ens, test_set, interval = FALSE)
 


### PR DESCRIPTION
Implements `predict.horizons_ensemble()` — the last unbuilt predict surface in the v1 pipeline API (roadmap A2). Replaces the skeleton that `cli_abort`ed "not implemented yet."

## What it does

Stacked-ensemble point predictions for new spectra, all three meta-learners:
- **weighted** — weighted average of member predictions by the stored coefficients
- **penalized / xgb** — member predictions widened to the `member_<config_id>` matrix and run through the fitted meta-workflow

Each member predicts via the existing `predict_one_config()` primitive (predict once, back-transform once). A new `predict_members()` helper assembles the long member-prediction frame; two combine helpers (`combine_ensemble_weighted`, `combine_ensemble_metamodel`) own the per-method combination.

## Design decisions

- **Authoritative member set = `$ensemble$weights$member`** — what the meta-model actually trained on, not a re-derivation from `cv_predictions`.
- **Abort on member failure, naming the config** — the combine is only valid over the exact member set seen at fit time; no renormalization. (`predict_one_config` aborts upstream; the metamodel path has an explicit member-presence gate; the weighted path now has NA-parity guard.)
- **`interval = TRUE` degrades gracefully to point-only** with a one-time note. This is the hook ensemble conformal UQ (A2b) fills later — the point path needs no rewrite. Ensemble UQ is **not** in this PR.

## Verification

- 64 ensemble tests / 0 fail; single-model predict path unaffected (28 / 0).
- **Round-trip:** predicting the held-out Split-F test set reproduces the stored `$ensemble$predictions` to numerical precision (`max|diff| = 0`) for all three methods.
- Hand-computed weighted combine, schema-gate reuse, graceful interval degradation, abort-on-failing-member, preflight.
- Ran `/horizons-review` (r-craft, leakage-lifecycle, s3-contract, evaluation-uq): no Critical; core correctness independently confirmed (no double back-transform, key-based combine, frozen trained state, non-circular round-trip). Three hardening fixes applied.

## Deferred (tracked for A2b / A3)

- Ensemble conformal UQ (CV+/CQR on the meta-OOF residuals) — researched, designed, separate build. When it lands: calibration must use a tuning-disjoint partition, and interval columns must join by `sample_id` (not `bind_cols`).
- `$ensemble$model` heterogeneous slot type (tibble vs workflow) — contract-doc gap for class hardening (A3).